### PR TITLE
Updates for podman

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -18,9 +18,6 @@ services:
       interval: 60s
       timeout: 30s
       retries: 12
-    links:
-      - elasticsearch:es
-      - redis:rs
     depends_on:
       elasticsearch:
         condition: service_healthy
@@ -44,8 +41,6 @@ services:
       - internal
     ports:
       - 5000:5000
-    links:
-      - conductor-server
     stdin_open: true
 
   redis:
@@ -53,24 +48,28 @@ services:
     volumes:
       - ./redis.conf:/usr/local/etc/redis/redis.conf
     networks:
-      - internal
+      internal:
+        aliases:
+          - rs
     ports:
       - 6379:6379
     healthcheck:
       test: [ "CMD", "redis-cli","ping" ]
 
   elasticsearch:
-    image: elasticsearch:6.8.15
+    image: jazzdev/elasticsearch:6.8.15-arm
     container_name: elasticsearch
     environment:
-      - "ES_JAVA_OPTS=-Xms512m -Xmx1024m"
+      - "ES_JAVA_OPTS=-Xms1024m -Xmx1024m"
       - transport.host=0.0.0.0
       - discovery.type=single-node
       - xpack.security.enabled=false
     volumes:
       - esdata-conductor:/usr/share/elasticsearch/data
     networks:
-      - internal
+      internal:
+        aliases:
+          - es
     ports:
       - 9200:9200
       - 9300:9300

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -57,7 +57,7 @@ services:
       test: [ "CMD", "redis-cli","ping" ]
 
   elasticsearch:
-    image: jazzdev/elasticsearch:6.8.15-arm
+    image: ghcr.io/jd-brennan/elasticsearch:6.8.15-arm
     container_name: elasticsearch
     environment:
       - "ES_JAVA_OPTS=-Xms1024m -Xmx1024m"

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -57,7 +57,7 @@ services:
       test: [ "CMD", "redis-cli","ping" ]
 
   elasticsearch:
-    image: ghcr.io/jd-brennan/elasticsearch:6.8.15-arm
+    image: quay.io/jd-brennan/elasticsearch:6.8.15-arm
     container_name: elasticsearch
     environment:
       - "ES_JAVA_OPTS=-Xms1024m -Xmx1024m"

--- a/docker/ui/Dockerfile
+++ b/docker/ui/Dockerfile
@@ -1,7 +1,7 @@
 #
 # conductor:ui - Netflix Conductor UI
 #
-FROM node:14-alpine
+FROM node:16-alpine
 LABEL maintainer="Netflix OSS <conductor@netflix.com>"
 
 # Install the required packages for the node build


### PR DESCRIPTION
Changes needed to run with podman:

1) don't use "links" in docker-compose.yaml (podman doesns't support this)
2) use arm version of elasticsearch (not podman related)
3) use node 16 (not podman related)

Steps to set up:
```
brew install podman-desktop
# Default of -m 2048 is not enough for Conductor containers (so use 5GB)
podman machine init -m 5120 --disk-size 200 --cpus 2 
sudo podman-mac-helper install # make podman engine compatible with `docker` command!
podman machine start

brew install docker
brew install docker-compose
brew install docker-credential-helper
```

Running conductor:
```
cd conductor
cd docker
# Can't build two images at once - it causes a race condition failure, so build UI first
docker-compose build conductor-ui 
docker-compose up -d
```

